### PR TITLE
Fix usage of positional after named arguments

### DIFF
--- a/did/shared/src/main/scala/fmgp/did/comm/protocol/mediatorcoordination2/Keylist.scala
+++ b/did/shared/src/main/scala/fmgp/did/comm/protocol/mediatorcoordination2/Keylist.scala
@@ -55,7 +55,7 @@ final case class KeylistUpdate(id: MsgID = MsgID(), from: FROM, to: TO, updates:
       return_route = Some(ReturnRoute.all), // Protocol expect recipient to get reply on the same channel
     )
   def makeKeylistResponse(updated: Seq[(FROMTO, KeylistAction, KeylistResult)]) =
-    KeylistResponse(thid = id, to = from.asTO, from = to.asFROM, updated)
+    KeylistResponse(thid = id, to = from.asTO, from = to.asFROM, updated = updated)
 }
 
 /** TODO we don't believe this behavior is correct or secure. But ismimic the behavior of RootsID mediator

--- a/did/shared/src/main/scala/fmgp/did/comm/protocol/mediatorcoordination3/Recipient.scala
+++ b/did/shared/src/main/scala/fmgp/did/comm/protocol/mediatorcoordination3/Recipient.scala
@@ -55,7 +55,7 @@ final case class RecipientUpdate(id: MsgID = MsgID(), from: FROM, to: TO, update
       return_route = Some(ReturnRoute.all), // Protocol expect recipient to get reply on the same channel
     )
   def makeRecipientResponse(updated: Seq[(FROMTO, RecipientAction, RecipientResult)]) =
-    RecipientResponse(thid = id, to = from.asTO, from = to.asFROM, updated)
+    RecipientResponse(thid = id, to = from.asTO, from = to.asFROM, updated = updated)
 }
 
 /** TODO we don't believe this behavior is correct or secure. But ismimic the behavior of RootsID mediator


### PR DESCRIPTION
Scala 3.4.x fixes a bug which did allowed to use positional arguments after named ones. These could have been misleading to users. The fix lead to failures of 3 Open Community Projects, one of them is this one. [Link to build logs](https://github.com/VirtusLab/community-build3/actions/runs/6593524845/job/17919459259) 

Merging this PR and applying the fix would allow for further testing this project against latest versions of Scala 3